### PR TITLE
Redesign site: light minimal single-page layout inspired by karpathy.ai

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@
 
 title: Tharindu Hewage
 author: Tharindu Hewage
-tagline: "Distributed systems engineer · PhD"
+tagline: "Distributed systems · PhD candidate · University of Melbourne"
 description: >-
   Distributed cloud systems engineer with a PhD and a rare middleware +
   node/OS-level perspective. Building reliable systems at scale.
@@ -23,13 +23,6 @@ profiles:
   medium: "https://medium.com/@tharindu-b-hewage"
   email: "tharindu.b.hewage@gmail.com"
 
-# Top navigation. `name` is shown verbatim (terminal command style).
-nav:
-  - { name: "whoami",   url: "/" }
-  - { name: "work",     url: "/work/" }
-  - { name: "research", url: "/research/" }
-  - { name: "code",     url: "/code/" }
-  - { name: "resume",   url: "/resume/" }
 
 # ---------------------------------------------------------------------------
 # Build settings

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -3,42 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#0d1117">
+  <meta name="theme-color" content="#ffffff">
   {% seo %}
   <link rel="icon" href="/assets/img/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/assets/css/main.css">
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
-
-  <header class="site-header">
-    <nav class="nav" aria-label="Primary">
-      <a class="nav-brand" href="/">tharindu<span class="accent">@</span>hewage.io</a>
-      <ul class="nav-links">
-        {% for item in site.nav %}
-        {% assign current = item.url | relative_url %}
-        <li>
-          <a href="{{ item.url | relative_url }}"
-             {% if page.url == item.url %}aria-current="page"{% endif %}>{{ item.name }}</a>
-        </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </header>
-
-  <main id="main" class="site-main">
-    {{ content }}
-  </main>
-
+  {{ content }}
   <footer class="site-footer">
-    <div class="footer-links">
-      {% if site.profiles.github %}<a href="{{ site.profiles.github }}">github</a>{% endif %}
-      {% if site.profiles.linkedin %}<a href="{{ site.profiles.linkedin }}">linkedin</a>{% endif %}
-      {% if site.profiles.scholar %}<a href="{{ site.profiles.scholar }}">scholar</a>{% endif %}
-      {% if site.profiles.medium %}<a href="{{ site.profiles.medium }}">medium</a>{% endif %}
-      {% if site.profiles.email %}<a href="mailto:{{ site.profiles.email }}">email</a>{% endif %}
-    </div>
-    <p class="footer-meta"><span class="muted">$</span> &copy; {{ 'now' | date: "%Y" }} {{ site.author }} · built with jekyll, no frameworks</p>
+    &copy; {{ 'now' | date: "%Y" }} Tharindu Hewage
   </footer>
 </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,52 +1,97 @@
 ---
 layout: base
 ---
-<section class="hero">
-  <p class="prompt"><span class="muted">$</span> whoami</p>
-  <h1 class="hero-title">
-    Tharindu Hewage<span class="cursor" aria-hidden="true"></span>
-  </h1>
-  <p class="hero-lead">
-    Distributed systems engineer with a <strong>PhD</strong> in distributed systems
-    and a rare <strong>middleware&nbsp;+&nbsp;node/OS-level</strong> perspective —
-    from cloud orchestration down to CPU cores.
-  </p>
-  <p class="hero-status">
-    <span class="accent">&gt;</span> Looking to join a team building distributed systems at scale.
-  </p>
-  <div class="hero-actions">
-    <a class="btn btn-primary" href="/resume/">resume</a>
-    <a class="btn" href="{{ site.profiles.github }}">github</a>
-    <a class="btn" href="{{ site.profiles.linkedin }}">linkedin</a>
-  </div>
-</section>
+<div class="page-wrap">
 
-{{ content }}
+  <header class="intro">
+    <img class="intro-photo" src="/assets/img/profile.png" alt="Tharindu Hewage">
+    <div>
+      <h1 class="intro-name">Tharindu Hewage</h1>
+      <p class="intro-tagline">{{ site.tagline }}</p>
+      <ul class="intro-links">
+        {% if site.profiles.github %}<li><a href="{{ site.profiles.github }}">GitHub</a></li>{% endif %}
+        {% if site.profiles.linkedin %}<li><a href="{{ site.profiles.linkedin }}">LinkedIn</a></li>{% endif %}
+        {% if site.profiles.scholar %}<li><a href="{{ site.profiles.scholar }}">Scholar</a></li>{% endif %}
+        {% if site.profiles.medium %}<li><a href="{{ site.profiles.medium }}">Medium</a></li>{% endif %}
+        {% if site.profiles.email %}<li><a href="mailto:{{ site.profiles.email }}">Email</a></li>{% endif %}
+      </ul>
+    </div>
+  </header>
 
-<section class="home-grid">
-  <a class="card-link" href="/work/">
-    <h2 class="card-title">work <span class="arrow">→</span></h2>
-    <p>PhD research and 3.5 years of enterprise middleware engineering at WSO2.</p>
-  </a>
-  <a class="card-link" href="/research/">
-    <h2 class="card-title">research <span class="arrow">→</span></h2>
-    <p>Peer-reviewed work on carbon-aware scheduling, from orchestration to hardware.</p>
-  </a>
-  <a class="card-link" href="/code/">
-    <h2 class="card-title">code <span class="arrow">→</span></h2>
-    <p>Open-source systems in Go, Java, Python — OpenStack, CPU power, distributed compute.</p>
-  </a>
-</section>
+  <div class="about">{{ content }}</div>
 
-<section class="home-featured">
-  <h2 class="section-label"><span class="muted">$</span> ls featured-projects/</h2>
-  <ul class="project-list">
-    {% for p in site.data.projects %}{% if p.featured %}
-    <li class="project">
-      <a class="project-name" href="{{ p.url }}">{{ p.name }}</a>
-      <p class="project-blurb">{{ p.blurb }}</p>
-      <ul class="tags">{% for t in p.tags %}<li>{{ t }}</li>{% endfor %}</ul>
-    </li>
-    {% endif %}{% endfor %}
-  </ul>
-</section>
+  <hr>
+
+  <section>
+    <h2>Education</h2>
+    <ul class="edu-list">
+      {% for ed in site.data.education %}
+      <li>
+        <p class="edu-degree">{{ ed.degree }}</p>
+        <p class="edu-org"><a href="{{ ed.org_url }}">{{ ed.org }}</a>, {{ ed.location }}</p>
+        <p class="edu-dates">{{ ed.start }}–{{ ed.end }}</p>
+        <p class="edu-note">{{ ed.note }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>Experience</h2>
+    <ul class="exp-list">
+      {% for job in site.data.experience %}
+      <li>
+        <p class="exp-role">{{ job.role }}</p>
+        <p class="exp-meta">
+          {% if job.org_url != "" %}<a href="{{ job.org_url }}">{{ job.org }}</a>{% else %}{{ job.org }}{% endif %}
+          &middot; {{ job.start }}–{{ job.end }} &middot; {{ job.location }}
+        </p>
+        {% if job.summary %}<p class="exp-summary">{{ job.summary }}</p>{% endif %}
+        <ul class="exp-points">
+          {% for pt in job.points %}<li>{{ pt }}</li>{% endfor %}
+        </ul>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>Research</h2>
+    {% assign me = site.data.publications.me %}
+    {% capture bold_me %}<strong>{{ me }}</strong>{% endcapture %}
+    <ul class="pub-list">
+      {% for pub in site.data.publications.items %}
+      <li>
+        <span class="pub-title">{{ pub.title }}</span>
+        <span class="pub-authors">{{ pub.authors | replace: me, bold_me }}</span>
+        <span class="pub-venue">{{ pub.venue }}{% if pub.location %}, {{ pub.location }}{% endif %} &middot; {{ pub.year }}</span>
+        <div class="pub-links">
+          {% if pub.links.paper %}<a href="{{ pub.links.paper }}">paper</a>{% endif %}
+          {% if pub.links.code %}<a href="{{ pub.links.code }}">code</a>{% endif %}
+          {% if pub.status %}<span class="pub-status">{{ pub.status }}</span>{% endif %}
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <hr>
+
+  <section>
+    <h2>Projects</h2>
+    <ul class="proj-list">
+      {% for p in site.data.projects %}
+      <li>
+        <a class="proj-name" href="{{ p.url }}">{{ p.name }}</a>
+        <p class="proj-blurb">{{ p.blurb }}</p>
+        <p class="proj-tags">{{ p.tags | join: " &middot; " }}</p>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+</div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,237 +1,123 @@
 /* ==========================================================================
-   hewage.io — dark terminal design system
-   One stylesheet, no frameworks. Tokens at :root; everything else composes them.
+   hewage.io — light minimal design
+   One stylesheet, no frameworks.
    ========================================================================== */
 
 :root {
-  --bg:        #0d1117;
-  --bg-soft:   #161b22;
-  --bg-hover:  #1c2230;
-  --fg:        #e6edf3;
-  --muted:     #8b949e;
-  --accent:    #3fb950;   /* terminal green */
-  --accent-dim:#2ea043;
-  --link:      #58a6ff;
-  --border:    #30363d;
-
-  --mono: ui-monospace, "JetBrains Mono", "SF Mono", "Menlo", "Consolas", monospace;
-
-  --maxw: 72ch;
-  --gap: clamp(1rem, 2.5vw, 1.75rem);
-  --radius: 6px;
+  --fg:     #1a1a1a;
+  --muted:  #555;
+  --link:   #0366d6;
+  --border: #e1e4e8;
+  --font:   -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --max-w:  680px;
 }
 
-/* ---------- reset ---------- */
 *, *::before, *::after { box-sizing: border-box; }
-html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+html { -webkit-text-size-adjust: 100%; }
 body {
   margin: 0;
-  background: var(--bg);
+  background: #fff;
   color: var(--fg);
-  font-family: var(--mono);
-  font-size: clamp(15px, 0.6vw + 13.5px, 17px);
+  font-family: var(--font);
+  font-size: 16px;
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
 }
 img { max-width: 100%; height: auto; display: block; }
 a { color: var(--link); text-decoration: none; }
 a:hover { text-decoration: underline; }
-ul { padding: 0; }
+ul, ol { padding: 0; }
+p { margin: 0 0 .75rem; }
 
-.muted { color: var(--muted); }
-.accent { color: var(--accent); }
-
-.skip-link {
-  position: absolute; left: -999px; top: 0;
-  background: var(--accent); color: var(--bg); padding: .5rem 1rem; z-index: 10;
-}
-.skip-link:focus { left: 0; }
-
-/* ---------- layout shell ---------- */
-.site-header, .site-main, .site-footer {
-  width: 100%;
-  max-width: 64rem;
-  margin-inline: auto;
-  padding-inline: var(--gap);
-}
-.site-main { padding-block: clamp(2rem, 6vw, 4rem); min-height: 60vh; }
-
-/* ---------- nav ---------- */
-.site-header { border-bottom: 1px solid var(--border); }
-.nav {
-  display: flex; flex-wrap: wrap; align-items: center; gap: .75rem 1.5rem;
-  padding-block: 1rem;
-}
-.nav-brand { color: var(--fg); font-weight: 700; margin-right: auto; }
-.nav-brand:hover { text-decoration: none; color: var(--accent); }
-.nav-links { list-style: none; display: flex; flex-wrap: wrap; gap: .25rem 1.1rem; margin: 0; }
-.nav-links a { color: var(--muted); }
-.nav-links a::before { content: ""; color: var(--accent); margin-right: .15rem; }
-.nav-links a:hover { color: var(--fg); text-decoration: none; }
-.nav-links a:hover::before { content: "/"; }
-.nav-links a[aria-current="page"] { color: var(--accent); }
-.nav-links a[aria-current="page"]::before { content: "/"; }
-
-/* ---------- hero ---------- */
-.hero { padding-block: clamp(1rem, 4vw, 2.5rem); border-bottom: 1px solid var(--border); }
-.prompt { color: var(--muted); margin: 0 0 .5rem; }
-.hero-title {
-  font-size: clamp(2rem, 6vw, 3.25rem); line-height: 1.1; margin: 0 0 1rem;
-  letter-spacing: -0.02em;
-}
-.cursor {
-  display: inline-block; width: .6ch; height: 1.05em; margin-left: .15ch;
-  background: var(--accent); transform: translateY(.12em);
-  animation: blink 1.1s steps(1) infinite;
-}
-@keyframes blink { 50% { opacity: 0; } }
-.hero-lead { font-size: clamp(1rem, 1.5vw, 1.2rem); max-width: var(--maxw); color: var(--fg); }
-.hero-lead strong { color: var(--accent); font-weight: 700; }
-.hero-status { color: var(--muted); max-width: var(--maxw); }
-.hero-actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 1.5rem; }
-
-/* ---------- buttons ---------- */
-.btn {
-  display: inline-block; padding: .5rem 1rem; border: 1px solid var(--border);
-  border-radius: var(--radius); color: var(--fg); background: var(--bg-soft);
-  font: inherit; cursor: pointer; transition: all .15s ease;
-}
-.btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
-.btn-primary { background: var(--accent-dim); border-color: var(--accent-dim); color: #0d1117; font-weight: 700; }
-.btn-primary:hover { background: var(--accent); border-color: var(--accent); color: #0d1117; }
-
-/* ---------- section labels ---------- */
-.section-label {
-  font-size: 1rem; color: var(--muted); font-weight: 400;
-  margin: clamp(2rem, 5vw, 3rem) 0 1rem; border-bottom: 1px dashed var(--border);
-  padding-bottom: .5rem;
+/* ---------- page shell ---------- */
+.page-wrap {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
 }
 
-/* ---------- home grid ---------- */
-.home-grid {
-  display: grid; gap: 1rem; margin-top: clamp(2rem, 5vw, 3rem);
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+/* ---------- intro / header ---------- */
+.intro {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin-bottom: 1.75rem;
 }
-.card-link {
-  display: block; padding: 1.25rem; border: 1px solid var(--border);
-  border-radius: var(--radius); background: var(--bg-soft); color: var(--fg);
-  transition: border-color .15s ease, transform .15s ease;
+.intro-photo {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
 }
-.card-link:hover { border-color: var(--accent); text-decoration: none; transform: translateY(-2px); }
-.card-title { margin: 0 0 .5rem; font-size: 1.15rem; color: var(--accent); }
-.card-link p { margin: 0; color: var(--muted); font-size: .92rem; }
-.arrow { transition: transform .15s ease; display: inline-block; }
-.card-link:hover .arrow { transform: translateX(.25rem); }
+.intro-name { font-size: 1.6rem; font-weight: 700; margin: 0 0 .2rem; line-height: 1.2; }
+.intro-tagline { color: var(--muted); margin: 0 0 .8rem; font-size: .95rem; }
+.intro-links { list-style: none; display: flex; flex-wrap: wrap; gap: .3rem 1.25rem; margin: 0; }
+.intro-links a { color: var(--muted); font-size: .9rem; }
+.intro-links a:hover { color: var(--fg); text-decoration: none; }
 
-/* ---------- project list ---------- */
-.project-list { list-style: none; margin: 0; display: grid; gap: 1rem; }
-.project {
-  padding: 1rem 1.25rem; border: 1px solid var(--border);
-  border-left: 3px solid var(--accent); border-radius: var(--radius);
-  background: var(--bg-soft);
-}
-.project-name { font-weight: 700; font-size: 1.05rem; }
-.project-blurb { margin: .4rem 0 .6rem; color: var(--fg); }
-.tags { list-style: none; display: flex; flex-wrap: wrap; gap: .4rem; margin: 0; }
-.tags li {
-  font-size: .75rem; color: var(--muted); padding: .15rem .55rem;
-  border: 1px solid var(--border); border-radius: 999px; background: var(--bg);
+/* ---------- about ---------- */
+.about { color: var(--fg); margin-bottom: 0; }
+
+/* ---------- section divider ---------- */
+hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+h2 {
+  font-size: .75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--muted);
+  margin: 0 0 1.25rem;
 }
 
-/* ---------- generic pages ---------- */
-.page-head { margin-bottom: 2rem; }
-.page-title { font-size: clamp(1.6rem, 4vw, 2.2rem); margin: 0 0 .25rem; }
-.page-subtitle { color: var(--muted); margin: 0; max-width: var(--maxw); }
-.page p, .page li { max-width: var(--maxw); }
+/* ---------- education ---------- */
+.edu-list { list-style: none; margin: 0; display: grid; gap: 1.25rem; }
+.edu-degree { font-weight: 600; margin: 0 0 .1rem; }
+.edu-org { margin: 0 0 .1rem; }
+.edu-dates { color: var(--muted); font-size: .875rem; margin: 0 0 .3rem; }
+.edu-note { color: var(--muted); font-size: .875rem; margin: 0; }
 
-/* ---------- timeline (work) ---------- */
-.timeline { list-style: none; margin: 0; border-left: 2px solid var(--border); }
-.tl-entry { position: relative; padding: 0 0 2rem 1.5rem; }
-.tl-entry::before {
-  content: ""; position: absolute; left: -7px; top: .55rem; width: 12px; height: 12px;
-  background: var(--accent); border-radius: 50%; box-shadow: 0 0 0 4px var(--bg);
-}
-.tl-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: .25rem .75rem; }
-.tl-role { font-weight: 700; font-size: 1.1rem; }
-.tl-org { color: var(--accent); }
-.tl-dates { color: var(--muted); font-size: .85rem; margin-left: auto; }
-.tl-loc { color: var(--muted); font-size: .85rem; margin: .1rem 0 .5rem; }
-.tl-summary { margin: .25rem 0 .5rem; }
-.tl-points { margin: .5rem 0; padding-left: 1.1rem; }
-.tl-points li { margin-bottom: .35rem; }
+/* ---------- experience ---------- */
+.exp-list { list-style: none; margin: 0; display: grid; gap: 2rem; }
+.exp-role { font-weight: 600; margin: 0 0 .15rem; }
+.exp-meta { color: var(--muted); font-size: .875rem; margin: 0 0 .5rem; }
+.exp-summary { margin: 0 0 .5rem; }
+.exp-points { margin: 0; padding-left: 1.2rem; }
+.exp-points li { margin-bottom: .3rem; }
 
-/* ---------- publications ---------- */
-.pub-list { list-style: none; margin: 0; display: grid; gap: 1.25rem; }
-.pub {
-  padding: 1rem 1.25rem; border: 1px solid var(--border); border-radius: var(--radius);
-  background: var(--bg-soft);
-}
-.pub-title-main { font-weight: 700; display: block; margin: .15rem 0 .35rem; }
-.pub-authors { color: var(--muted); font-size: .9rem; }
-.pub-authors strong { color: var(--fg); }
-.pub-venue { color: var(--muted); font-size: .85rem; }
-.pub-links { margin-top: .6rem; display: flex; gap: .5rem; flex-wrap: wrap; }
-.pub-links a, .pub-status {
-  font-size: .75rem; padding: .2rem .6rem; border: 1px solid var(--border);
-  border-radius: var(--radius);
-}
-.pub-status { color: var(--muted); }
+/* ---------- research ---------- */
+.pub-list { list-style: none; margin: 0; display: grid; gap: 1.5rem; }
+.pub-title { font-weight: 600; display: block; margin-bottom: .2rem; }
+.pub-authors { color: var(--muted); font-size: .875rem; display: block; }
+.pub-venue { color: var(--muted); font-size: .825rem; display: block; margin-top: .1rem; }
+.pub-links { margin-top: .4rem; display: flex; gap: .75rem; flex-wrap: wrap; align-items: center; }
+.pub-links a { font-size: .85rem; }
+.pub-status { font-size: .825rem; color: var(--muted); }
 
-/* ---------- resume ---------- */
-.resume { max-width: 52rem; }
-.resume-head { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; justify-content: space-between; }
-.resume-name { font-size: clamp(1.7rem, 4vw, 2.3rem); margin: 0; }
-.resume-tagline { color: var(--muted); margin: .15rem 0 0; }
-.resume-contact { list-style: none; display: flex; flex-wrap: wrap; gap: .5rem 1.25rem; margin: 1rem 0 2rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border); font-size: .85rem; }
-.resume-section { margin-bottom: 2rem; }
-.resume-h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: .08em; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: .35rem; margin-bottom: 1rem; }
-.resume-entry { margin-bottom: 1.25rem; }
-.resume-entry-head { display: flex; flex-wrap: wrap; gap: .25rem .75rem; align-items: baseline; }
-.resume-role { font-weight: 700; }
-.resume-dates { color: var(--muted); font-size: .85rem; margin-left: auto; }
-.resume-loc { color: var(--muted); font-size: .85rem; margin: .1rem 0 .4rem; }
-.resume-points { margin: .4rem 0; padding-left: 1.1rem; }
-.resume-points li { margin-bottom: .3rem; }
-.resume-skills { margin: 0; display: grid; gap: .5rem; }
-.resume-skills > div { display: grid; grid-template-columns: 12rem 1fr; gap: 1rem; }
-.resume-skills dt { font-weight: 700; color: var(--muted); margin: 0; }
-.resume-skills dd { margin: 0; }
-.resume-pubs { list-style: none; margin: 0; display: grid; gap: .75rem; padding: 0; }
-.resume-pubs .pub-title { font-style: italic; }
+/* ---------- projects ---------- */
+.proj-list { list-style: none; margin: 0; display: grid; gap: 1.25rem; }
+.proj-name { font-weight: 600; }
+.proj-blurb { color: var(--fg); font-size: .925rem; margin: .15rem 0 .2rem; }
+.proj-tags { color: var(--muted); font-size: .825rem; margin: 0; }
 
 /* ---------- footer ---------- */
-.site-footer { border-top: 1px solid var(--border); padding-block: 2rem; margin-top: 2rem; }
-.footer-links { display: flex; flex-wrap: wrap; gap: 1rem; }
-.footer-links a { color: var(--muted); }
-.footer-links a:hover { color: var(--accent); }
-.footer-meta { color: var(--muted); font-size: .8rem; margin: 1rem 0 0; }
+.site-footer {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 2.5rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: .8rem;
+}
 
-/* ---------- 404 ---------- */
-.notfound { text-align: center; padding-block: clamp(2rem, 10vw, 6rem); }
-.notfound h1 { font-size: clamp(3rem, 12vw, 6rem); margin: 0; color: var(--accent); }
+/* ---------- accessibility ---------- */
+:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
 
-/* ---------- accessibility / motion ---------- */
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (max-width: 480px) {
+  .intro { flex-direction: column; }
+  .intro-photo { width: 72px; height: 72px; }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after { animation: none !important; transition: none !important; scroll-behavior: auto; }
-  .cursor { opacity: 1; }
-}
-
-/* ---------- responsive ---------- */
-@media (max-width: 38rem) {
-  .resume-skills > div { grid-template-columns: 1fr; gap: .1rem; }
-  .tl-dates, .resume-dates { margin-left: 0; }
-}
-
-/* ---------- print (resume → PDF) ---------- */
-@media print {
-  :root { --bg:#fff; --bg-soft:#fff; --fg:#111; --muted:#555; --accent:#000; --link:#000; --border:#ccc; }
-  body { font-size: 11pt; line-height: 1.4; }
-  .site-header, .site-footer, .no-print, .skip-link { display: none !important; }
-  .site-main { padding: 0; max-width: 100%; }
-  .resume { max-width: 100%; }
-  .resume-h2 { color: #000; }
-  a { color: #000; text-decoration: none; }
-  .resume-section { margin-bottom: 1rem; break-inside: avoid; }
-  .resume-entry { break-inside: avoid; }
+  *, *::before, *::after { transition: none !important; animation: none !important; }
 }

--- a/index.html
+++ b/index.html
@@ -1,12 +1,6 @@
 ---
 layout: home
-title: "Tharindu Hewage — Distributed Systems Engineer"
+title: "Tharindu Hewage"
+description: "PhD candidate building distributed systems for sustainable cloud computing — from orchestration down to Linux power management and CPU hardware."
 ---
-<section class="highlights">
-  <h2 class="section-label"><span class="muted">$</span> cat highlights.txt</h2>
-  <ul class="tl-points">
-    <li>Ran <a href="https://github.com/wso2/product-is/commits?author=tharindu-b-hewage">production middleware for enterprise</a> at WSO2 — open-source identity &amp; access management.</li>
-    <li>Built practical research systems, e.g. an <a href="https://github.com/crunchycookie/openstack-gc">OpenStack extension for carbon-aware real-time computing</a>.</li>
-    <li>Went node-level: learned Go and the Linux kernel power stack to <a href="https://github.com/crunchycookie/core-power-mgt">control per-core CPU power features</a> from the cloud control plane.</li>
-  </ul>
-</section>
+<p>PhD candidate at the University of Melbourne's <a href="http://clouds.cis.unimelb.edu.au/">CLOUDS Lab</a>, building distributed systems for sustainable cloud datacenters. My work spans the full stack: cloud orchestration, Linux operating systems, and CPU-level power hardware. Former enterprise middleware engineer at <a href="https://wso2.com">WSO2</a>. Looking to join a team building distributed infrastructure at scale.</p>

--- a/resume.md
+++ b/resume.md
@@ -1,5 +1,0 @@
----
-layout: resume
-title: resume
-permalink: /resume/
----


### PR DESCRIPTION
- Replace dark terminal theme with white background, system sans-serif
- Collapse multi-page nav into one scrollable page (Education → Experience → Research → Projects)
- Add profile photo to intro header; remove all terminal decorators
- Delete resume page
- Rewrite CSS from scratch; simplify base layout shell